### PR TITLE
[fix]自動更新機能の負荷軽減

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -50,6 +50,10 @@ $(function() {
 
   function message_update() {
     let lastMessageId = $('.main-messages__message').last().data('id');
+
+    //lastMessageIDが取得できない場合は何もしない。
+    if (typeof lastMessageId === "undefined") {return;}
+
     $.ajax({
       type: "GET",
       url: location.href,


### PR DESCRIPTION
## 実装内容
自動更新は5秒周期で以下の処理を行なっている。

 - 1)Webページの情報取得
 - 2)サーバーとやりとり

現状ではサーバーへ要求する必要のないページでも、
2)が行われてしまうため、1-2)サーバーとやりとりするか？」
という条件を追加しサーバー負荷の軽減を行う。

## 補足説明
そもそも、1)の前に条件を追加して処理自体を止めれないか色々検討したが
上手くいかなかったので、今回の実装で対処する。