### PR TITLE
[fix]メッセージが１つもないと自動更新されない問題の修正

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,6 @@
 $(function() {
+  let message_update_time = -1;
+
   function buildMessageHTML(message) {
     add_image = (message.image) ? `<p class='main-messages__message__image'><img src="${message.image}"></p>` : '';
     html = `
@@ -43,15 +45,13 @@ $(function() {
     });
   });
 
-  $(function() {
-    setInterval(message_update, 5000);
+  $(document).on('turbolinks:load', function() {
+    if (message_update_time > 0) {clearInterval(message_update_time);}
+    message_update_time = (location.href.match(/\/groups\/\d+\/messages/)) ? setInterval(message_update, 5000) : -1;
   });
 
   function message_update() {
     let lastMessageId = $('.main-messages__message').last().data('id');
-
-    //lastMessageIDが取得できない場合は何もしない。
-    if (typeof lastMessageId === "undefined") {return;}
 
     $.ajax({
       type: "GET",


### PR DESCRIPTION
[関連コミット]
6dadd5005ba2d4105582d08ed0d353a847a16a2e

[不具合と原因]
自動更新機能の負荷軽減対策として、メッセージIDが取得できない場合はサーバーへ自動更新要求しない実装にしていた。
しかし、これだとグループチャットにメッセージが１つもないケースでもメッセージIDを取得できないため、サーバーへ自動更新要求を行わない不具合が発覚した。

[対策]
現在の環境ではターボリンクが有効になっており、一度読み込んだjavascriptはリンククリックによる画面遷移では再読み込みされず自動更新処理制御部分が呼ばれないのが根本原因。
よって、自動更新制御処理は毎回ロードするようにjavascirp側のターボリンク設定を変更し、ページ遷移するたびに自動更新処理の開始・停止を判断するように修正することで対処した。

[time]2019/03/19-14:02